### PR TITLE
chore: update instructions for the deploy command

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -37,23 +37,24 @@ commands:
       commandLine: node --inspect=9229 .
       group:
         kind: run
-  - id: 3-deploy
-    exec:
-      label: Deploy application
-      component: tools
-      workingDir: ${PROJECTS_ROOT}/nodejs-configmap
-      commandLine: npm run openshift
-      group:
-        kind: run
-  - id: 4-deploy-info
+  - id: 3-deploy-info
     exec:
       label: Before deploy
       component: tools
       workingDir: ${PROJECTS_ROOT}/nodejs-configmap
       commandLine: |
           echo
-          echo "Before you can deploy this application to an openshift cluster,"
-          echo "you must run 'oc login ...' in the tools terminal."
+          echo "You are already logged in to the current cluster. However, if you want"
+          echo "to deploy this application to a different OpenShift cluster, you must"
+          echo "run 'oc login ...' in the tools terminal."
           echo
+      group:
+        kind: run
+  - id: 4-deploy
+    exec:
+      label: Deploy application
+      component: tools
+      workingDir: ${PROJECTS_ROOT}/nodejs-configmap
+      commandLine: oc project $DEVWORKSPACE_NAMESPACE && npm run openshift
       group:
         kind: run


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>
- Update deploy-info command
- Use DEVWORKSPACE_NAMESPACE env to select project where the application will be deployed
![screenshot-devspaces apps ocp411 crw-qe com-2022 08 18-12_33_26](https://user-images.githubusercontent.com/1271546/185363199-ec49d50c-cbe4-423a-a1c4-748898ac013a.png)

Related issue: https://issues.redhat.com/browse/CRW-3214
